### PR TITLE
rtrim to clean git output (ftw)

### DIFF
--- a/new_relic_deploy/new_relic_deploy.php
+++ b/new_relic_deploy/new_relic_deploy.php
@@ -48,6 +48,9 @@ elseif ($_POST['wf_type'] == 'deploy') {
   $user = $_POST['user_email'];
 }
 
+$revision = rtrim($revision, "\n");
+$changelog = rtrim($revision, "\n");
+
 $deployment_data = [
   "deployment" => [
     "revision" => $revision,


### PR DESCRIPTION
Fixes a 'bad request' error, the internal process that creates the tag for test and live env was adding a \n to the end of the git output for revision and changelog, which was denied by the API